### PR TITLE
If a property is also an attribute, use removeAttribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "purescript-unsafe-coerce": "^4.0.0",
     "purescript-bifunctors": "^4.0.0",
     "purescript-refs": "^4.1.0",
-    "purescript-foreign": "^5.0.0"
+    "purescript-foreign": "^5.0.0",
+    "purescript-st": "4.0.0"
   },
   "devDependencies": {
     "purescript-js-timers": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -31,8 +31,7 @@
     "purescript-unsafe-coerce": "^4.0.0",
     "purescript-bifunctors": "^4.0.0",
     "purescript-refs": "^4.1.0",
-    "purescript-foreign": "^5.0.0",
-    "purescript-st": "4.0.0"
+    "purescript-foreign": "^5.0.0"
   },
   "devDependencies": {
     "purescript-js-timers": "^4.0.0",

--- a/src/Halogen/VDom/DOM/Prop.purs
+++ b/src/Halogen/VDom/DOM/Prop.purs
@@ -194,9 +194,9 @@ unsafeGetProperty = Util.unsafeGetAny
 
 removeProperty ∷ EFn.EffectFn2 String DOM.Element Unit
 removeProperty = EFn.mkEffectFn2 \key el →
-  EFn.runEffectFn3 Util.hasAttribute null key el >>= case _ of
-    true -> EFn.runEffectFn3 Util.removeAttribute null key el
-    false -> case typeOf (Fn.runFn2 Util.unsafeGetAny key el) of
+  EFn.runEffectFn3 Util.hasAttribute null key el >>= if _
+    then EFn.runEffectFn3 Util.removeAttribute null key el
+    else case typeOf (Fn.runFn2 Util.unsafeGetAny key el) of
       "string" → EFn.runEffectFn3 Util.unsafeSetAny key "" el
       _        → case key of
         "rowSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el

--- a/src/Halogen/VDom/DOM/Prop.purs
+++ b/src/Halogen/VDom/DOM/Prop.purs
@@ -13,7 +13,7 @@ import Prelude
 
 import Data.Function.Uncurried as Fn
 import Data.Maybe (Maybe(..))
-import Data.Nullable (toNullable)
+import Data.Nullable (null, toNullable)
 import Data.Tuple (Tuple(..), fst, snd)
 import Effect (Effect)
 import Effect.Ref as Ref
@@ -194,9 +194,11 @@ unsafeGetProperty = Util.unsafeGetAny
 
 removeProperty ∷ EFn.EffectFn2 String DOM.Element Unit
 removeProperty = EFn.mkEffectFn2 \key el →
-  case typeOf (Fn.runFn2 Util.unsafeGetAny key el) of
-    "string" → EFn.runEffectFn3 Util.unsafeSetAny key "" el
-    _        → case key of
-      "rowSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el
-      "colSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el
-      _ → EFn.runEffectFn3 Util.unsafeSetAny key Util.jsUndefined el
+  EFn.runEffectFn3 Util.hasAttribute null key el >>= case _ of
+    true -> EFn.runEffectFn3 Util.removeAttribute null key el
+    false -> case typeOf (Fn.runFn2 Util.unsafeGetAny key el) of
+      "string" → EFn.runEffectFn3 Util.removeAttribute null key el
+      _        → case key of
+        "rowSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el
+        "colSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el
+        _ → EFn.runEffectFn3 Util.unsafeSetAny key Util.jsUndefined el

--- a/src/Halogen/VDom/DOM/Prop.purs
+++ b/src/Halogen/VDom/DOM/Prop.purs
@@ -197,7 +197,7 @@ removeProperty = EFn.mkEffectFn2 \key el →
   EFn.runEffectFn3 Util.hasAttribute null key el >>= case _ of
     true -> EFn.runEffectFn3 Util.removeAttribute null key el
     false -> case typeOf (Fn.runFn2 Util.unsafeGetAny key el) of
-      "string" → EFn.runEffectFn3 Util.removeAttribute null key el
+      "string" → EFn.runEffectFn3 Util.unsafeSetAny key "" el
       _        → case key of
         "rowSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el
         "colSpan" → EFn.runEffectFn3 Util.unsafeSetAny key 1 el

--- a/src/Halogen/VDom/Util.js
+++ b/src/Halogen/VDom/Util.js
@@ -149,6 +149,14 @@ exports.removeAttribute = function (ns, attr, el) {
   }
 };
 
+exports.hasAttribute = function (ns, attr, el) {
+  if (ns != null) {
+    el.hasAttributeNS(ns, attr);
+  } else {
+    el.hasAttribute(attr);
+  }
+};
+
 exports.addEventListener = function (ev, listener, el) {
   el.addEventListener(ev, listener, false);
 };

--- a/src/Halogen/VDom/Util.purs
+++ b/src/Halogen/VDom/Util.purs
@@ -24,6 +24,7 @@ module Halogen.VDom.Util
   , parentNode
   , setAttribute
   , removeAttribute
+  , hasAttribute
   , addEventListener
   , removeEventListener
   , JsUndefined
@@ -156,6 +157,9 @@ foreign import setAttribute
 
 foreign import removeAttribute
   ∷ EFn.EffectFn3 (Nullable Namespace) String DOM.Element Unit
+
+foreign import hasAttribute
+  ∷ EFn.EffectFn3 (Nullable Namespace) String DOM.Element Boolean
 
 foreign import addEventListener
   ∷ EFn.EffectFn3 String DOM.EventListener DOM.Element Unit


### PR DESCRIPTION
## The problem

A reproducible [Demo](https://rnons.github.io/halogen-rerender-props-issue/#Hello)

1. On initial render, the view is
  ```html
  <div>
    <a>hello</a>
    <button>toggle</button>
  </div>
  ```
2. Click on the toggle button, the `<a>` element becomes
  ```html
  <a href="https://github.com" title="hello">hello</a>
  ```
3. Click on the toggle button again, the `<a>` element becomes
  ```html
  <a href="">hello</a>
  ```

What I really want is `<a>hello</a>`

The fix is based on https://javascript.info/dom-attributes-and-properties#property-attribute-synchronization
> When a standard attribute changes, the corresponding property is auto-updated, and (with some exceptions) vice versa.
