### PR TITLE
Fix unsafeEqThunk equality check

### DIFF
--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -84,7 +84,7 @@ unsafeEqThunk ∷ ∀ f i. Fn.Fn2 (Thunk f i) (Thunk f i) Boolean
 unsafeEqThunk = Fn.mkFn2 \(Thunk a1 b1 _ d1) (Thunk a2 b2 _ d2) →
   Fn.runFn2 Util.refEq a1 a2 &&
   Fn.runFn2 Util.refEq b1 b2 &&
-  Fn.runFn2 a1 d1 d2
+  Fn.runFn2 b1 d1 d2
 
 type ThunkState f i a w =
   { thunk ∷ Thunk f i

--- a/src/Halogen/VDom/Thunk.purs
+++ b/src/Halogen/VDom/Thunk.purs
@@ -84,7 +84,7 @@ unsafeEqThunk ∷ ∀ f i. Fn.Fn2 (Thunk f i) (Thunk f i) Boolean
 unsafeEqThunk = Fn.mkFn2 \(Thunk a1 b1 _ d1) (Thunk a2 b2 _ d2) →
   Fn.runFn2 Util.refEq a1 a2 &&
   Fn.runFn2 Util.refEq b1 b2 &&
-  Fn.runFn2 Util.refEq d1 d2
+  Fn.runFn2 a1 d1 d2
 
 type ThunkState f i a w =
   { thunk ∷ Thunk f i


### PR DESCRIPTION
I was testing `Halogen.HTML.lazy` / `lazy2` / etc. in a small project, and noticed that `lazy2` never seemed to fire in a situation like this:

```purs
type State = { color :: String, colorConstant :: String, targets :: Array Int }

data Action = ToggleColor

render state =
  HH.div_ $ map (HH.lazy2 renderExpensive state.colorConstant) state.targets

renderExpensive :: String -> Int -> H.ComponentHTML
renderExpensive color target = ...expensive render call including onClick \_ -> Just Toggle

handleAction ToggleColor = do
  state <- H.get
  if state.color == "white" then
    H.modify_ _ { color = "red" }
  else
    H.modify_ _ { color = "white" }
```

When the `Toggle` action occurred the `color` field would change in state, and then `renderExpensive` would be called, even though it should be lazy based on referential equality wrt `colorConstant` and `targets`, which haven't changed.

This fix updates `unsafeEqThunk` to perform referential equality on the thunk ids and equality functions, but then uses the thunk's equality function on its arguments instead of refEq.

Using this fix, in the above example `lazy2` does fire correctly.

If desired I can package up the example in a runnable project.